### PR TITLE
build: generate PDB / dSYM

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -29,8 +29,10 @@
             'sources': ['src/impl_win.cc'],
             'defines': ['UNICODE'],
             'libraries': ['Shlwapi.lib'],
-            'msbuild_settings': {
-              'DebugInformationFormat': 3
+            'msvs_settings': {
+                'VCCLCompilerTool': {
+                  'DebugInformationFormat': 3
+                }
             }
           },
           # else

--- a/binding.gyp
+++ b/binding.gyp
@@ -20,6 +20,8 @@
             'sources': ['src/impl_mac.mm'],
             'xcode_settings': {
               'OTHER_LDFLAGS': ['-framework Foundation'],
+              'GCC_GENERATE_DEBUGGING_SYMBOLS': 'YES',
+              "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym",
             },
           },
           'OS=="win"',
@@ -27,6 +29,9 @@
             'sources': ['src/impl_win.cc'],
             'defines': ['UNICODE'],
             'libraries': ['Shlwapi.lib'],
+            'msbuild_settings': {
+              'DebugInformationFormat': 3
+            }
           },
           # else
           {


### PR DESCRIPTION
Adds gyp options to build dSYM and PDB files that can be uploaded to crash reporting services to symbolicate crashes from within this native module